### PR TITLE
Support `assert.plan` method

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,8 +26,7 @@ function wrapCluster(tape, Cluster) {
             testFn(testName, onAssert);
 
             function onAssert(assert) {
-                var _end = assert.end;
-                assert.end = asyncEnd;
+                assert.on('end', asyncEnd);
 
                 options.assert = assert;
                 var cluster = new Cluster(options);
@@ -52,8 +51,6 @@ function wrapCluster(tape, Cluster) {
                         if (err2) {
                             assert.ifError(err2);
                         }
-
-                        _end.call(assert);
                     }
                 }
             }

--- a/test/index.js
+++ b/test/index.js
@@ -52,3 +52,16 @@ MyTestCluster.test('a test', {
         assert.end();
     });
 });
+
+MyTestCluster.test('t.plan test', {
+      port: 8000
+}, function t(cluster, assert) {
+    request({
+        url: 'http://localhost:' + cluster.port + '/bar'
+    }, function onResponse(err, resp, body) {
+        assert.plan(3);
+        assert.ifError(err);
+        assert.equal(resp.statusCode, 200);
+        assert.equal(resp.body, '/bar');
+    });
+});


### PR DESCRIPTION
Tape has a [`plan` method](https://github.com/substack/tape#tplann) we can use as an alternative to calling `end`. However, this was not supported by tape-cluster and unit tests would hang.

In this PR, instead of overwriting the `assert.end` function, we listen for the `assert.end` event then call the `asyncEnd` method. This allows us to use the `assert.plan` method as well as `assert.end`. 