### PR TITLE
Support `libtap` as `tap` dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -213,7 +213,7 @@ class TapeHarness {
       const caller = errorLines[2]
 
       // TAP: call through because plan is called internally
-      if (/node_modules[/?][\\?\\?]?tap/.test(caller)) {
+      if (/node_modules[/?][\\?\\?]?(?:lib)?tap/.test(caller)) {
         return _plan.call(assert, count)
       }
 


### PR DESCRIPTION
In newer versions of `tap`; the `tap` stuff seems to be in `libtap` instead

Signed-off-by: Juan José Arboleda <soyjuanarbol@gmail.com>